### PR TITLE
chore(build): bump sling-bundle-parent from 62 to 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Updates the Apache Sling bundle parent POM version to pick up the latest build tooling, dependency management, and plugin updates included in versions 63–66.

- Bumped `sling-bundle-parent` version from `62` to `66` in `pom.xml`

Co-authored-by: Maia <maia@noreply>