### PR TITLE
chore(deps): bump sling-bundle-parent from 62 to 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Updates the Apache Sling bundle parent POM version to pick up the latest build tooling, plugin management, and dependency updates included in versions 63–66.

- `pom.xml`: upgrade `sling-bundle-parent` parent version from `62` to `66`

Co-authored-by: Maia <maia@noreply>